### PR TITLE
NEW approach! No fragmentation!

### DIFF
--- a/pyprox_tcp.py
+++ b/pyprox_tcp.py
@@ -130,14 +130,10 @@ class ThreadedServer(object):
 
 def send_data_in_fragment(data , sock):
     
-    for i in range(0, len(data), L_fragment):
-        fragment_data = data[i:i+L_fragment]
-        print('send ',len(fragment_data),' bytes')                        
-        
-        # sock.send(fragment_data)
-        sock.sendall(fragment_data)
-
-        time.sleep(fragment_sleep)
+    index_start = data.find(b'Host: ')+6 #start of Host:
+    index_end = data[index_start:].find(b'\r')+index_start #end of Host: 
+    data = data[:index_start]+data[index_start:index_end].upper()+data[index_end:]
+    print(f"{data}")
 
     print('----------finish------------')
 


### PR DESCRIPTION
این تست خیلی جالبیه که بنظرم میشه از توش یچیزی شاید درورد.
مقدار Host رو بصورت رندم capital میکنیم و از فیلترینگ رد میشیم. دیگه نیاز به فرگمنت کردن نیست.

البته حتما باید روی پروکسی ست بشه:
`curl -x 127.0.0.1:2500 "--header "Host: youtube.com" $IP` 
 در ریکوست Host: YOUTUBE.COM  تبدیل میشه و
از فیلترینگ رد میشه. حتی Youtube.COm  یا ... رد میشن


نکته مهم اینه
`curl  "--header "Host: youtube.com" 127.0.0.1:2500 
از فیلترینگ رد نمیشه

