### PR TITLE
get listening port from environment if set

### DIFF
--- a/pyprox_tcp.py
+++ b/pyprox_tcp.py
@@ -19,7 +19,8 @@ if os.name == 'posix':
 
 
 
-listen_PORT = 2500    # pyprox listening to 127.0.0.1:listen_PORT
+# get listening port from environment if set
+listen_PORT = int(os.getenv('LISTEN_PORT', 2500))    # pyprox listening to 127.0.0.1:listen_PORT
 
 Cloudflare_IP = '162.159.135.42'   # plos.org (can be any dirty cloudflare ip)
 Cloudflare_port = 443

--- a/pyprox_tcp_randchunk.py
+++ b/pyprox_tcp_randchunk.py
@@ -20,7 +20,8 @@ if os.name == 'posix':
 
 
 
-listen_PORT = 2500    # pyprox listening to 127.0.0.1:listen_PORT
+# get listening port from environment if set
+listen_PORT = int(os.getenv('LISTEN_PORT', 2500))    # pyprox listening to 127.0.0.1:listen_PORT
 
 Cloudflare_IP = '162.159.135.42'   # plos.org (can be any dirty cloudflare ip)
 # Cloudflare_IP = '162.159.36.93'  # 


### PR DESCRIPTION
This is valuable when using port 443 in combination with cloudflare workers in order to set so called "clean ip" as 127.0.0.1 and port 443